### PR TITLE
fix: Remove `interchangable_with` attr from `__hash__` method

### DIFF
--- a/stockholm/currency.py
+++ b/stockholm/currency.py
@@ -119,7 +119,6 @@ class MetaCurrency(type):
                 "stockholm.MetaCurrency",
                 self.ticker,
                 self.decimal_digits,
-                self.interchangeable_with,
                 self.preferred_ticker,
             )
         )
@@ -231,7 +230,12 @@ class BaseCurrencyType(metaclass=MetaCurrency):
 
     def __hash__(self) -> int:
         return hash(
-            ("stockholm.Currency", self.ticker, self.decimal_digits, self.interchangeable_with, self.preferred_ticker)
+            (
+                "stockholm.Currency",
+                self.ticker,
+                self.decimal_digits,
+                self.preferred_ticker,
+            )
         )
 
     def __bool__(self) -> bool:

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -186,11 +186,15 @@ def test_custom_currency():
 
 
 def test_currency_hashable() -> None:
+    class CNY(BaseCurrency):
+        interchangeable_with = ("CNH", "RMB")
+
     EUR = Currency("EUR")
 
     class SEK(BaseCurrency):
         pass
 
+    assert hash(CNY)
     assert hash(EUR)
     assert hash(SEK)
 


### PR DESCRIPTION
### Description

Calling `hash(Currency.CODE)` on any class that defines `interchangable_with`, returns an error `TypeError: unhashable type: 'list'`.

### Fix

I went ahead and removed `interchangable_with` from the `__hash__` method, but if keeping this is preferred we could alternatively join the list.

Might need a larger version bump since users of the library could have these hashes stored somewhere.