### PR TITLE
Specific keys to asdict() function + number class + improved documentation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         python tests/types/implementation_test.py
         python tests/types/conversion_type.py
+        python tests/examples/bankfile_test.py
     - name: Codecov
       run: |
         codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.5.4] - 2022-XX-XX
+
+* The `money.asdict()` function can now be called with an optional `keys` argument, which can be used to specify a tuple of keys which shuld be used in the returned dict.
+
+  The default behaviour has not changed. `money.asdict()` is equivalent to `money.asdict(keys=("value", "units", "nanos", "currency_code"))`.
+
+  Values to use in the `keys` tuple for `stockholm.Money` objects are any combination of the following:
+
+  | key | description | return type | example |
+  | :-- | :---------- | :---------- | -------: |
+  | `value` | amount + currency code | `str` | `"9001.50 USD"`
+  | `units` | units of the amount | `int` | `9001` |
+  | `nanos` | number of nano units of the amount | `int` | `500000000` |
+  | `currency_code` | currency code if available | `str \| None` | `"USD"` |
+  | `currency` | currency code if available | `str \| None` | `"USD"` |
+  | `amount` | the monetary amount (excl. currency code) | `str` | `"9001.50"` |
+
+  Code example:
+
+  ```python
+  from stockholm import Money
+
+  Money("4711 USD").asdict(keys=("value", "units", "nanos", "currency_code"))
+  # {'value': '4711.00 USD', 'units': 4711, 'nanos': 0, 'currency_code': 'USD'}
+
+  Money("4711 USD").asdict(keys=("amount", "currency"))
+  # {'amount': '4711.00', 'currency': 'USD'}
+
+  Money(nanos=10).asdict(keys=("value", "currency", "units", "nanos"))
+  # {'value': '0.00000001', 'currency': None, 'units': 0, 'nanos': 10}
+  ```
+
+
 ## [0.5.3] - 2022-10-25
 
 * Python 3.11 added to test matrix and trove classifiers to officially claim support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,34 +3,38 @@
 ## [0.5.4] - 2022-XX-XX
 
 * The `money.asdict()` function can now be called with an optional `keys` argument, which can be used to specify a tuple of keys which shuld be used in the returned dict.
+* A `Number` class has been added, which can be used to differentiate between monetary values and values that doesn't hold a currency – `stockholm.Number`. Like `Rate` objects, the `Number` objects cannot be instantiated with a currency or currency code.
+* Added additional documentation and examples to the README.
 
-  The default behaviour has not changed. `money.asdict()` is equivalent to `money.asdict(keys=("value", "units", "nanos", "currency_code"))`.
+#### How to use `money.asdict(keys)`
 
-  Values to use in the `keys` tuple for `stockholm.Money` objects are any combination of the following:
+The default behaviour for `money.asdict()` has not changed. `money.asdict()` is equivalent to `money.asdict(keys=("value", "units", "nanos", "currency_code"))`.
 
-  | key | description | return type | example |
-  | :-- | :---------- | :---------- | -------: |
-  | `value` | amount + currency code | `str` | `"9001.50 USD"`
-  | `units` | units of the amount | `int` | `9001` |
-  | `nanos` | number of nano units of the amount | `int` | `500000000` |
-  | `currency_code` | currency code if available | `str \| None` | `"USD"` |
-  | `currency` | currency code if available | `str \| None` | `"USD"` |
-  | `amount` | the monetary amount (excl. currency code) | `str` | `"9001.50"` |
+Values to use in the `keys` tuple for `stockholm.Money` objects are any combination of the following:
 
-  Code example:
+| key | description | return type | example |
+| :-- | :---------- | :---------- | -------: |
+| `value` | amount + currency code | `str` | `"9001.50 USD"`
+| `units` | units of the amount | `int` | `9001` |
+| `nanos` | number of nano units of the amount | `int` | `500000000` |
+| `currency_code` | currency code if available | `str \| None` | `"USD"` |
+| `currency` | currency code if available | `str \| None` | `"USD"` |
+| `amount` | the monetary amount (excl. currency code) | `str` | `"9001.50"` |
 
-  ```python
-  from stockholm import Money
+Code example:
 
-  Money("4711 USD").asdict(keys=("value", "units", "nanos", "currency_code"))
-  # {'value': '4711.00 USD', 'units': 4711, 'nanos': 0, 'currency_code': 'USD'}
+```python
+from stockholm import Money
 
-  Money("4711 USD").asdict(keys=("amount", "currency"))
-  # {'amount': '4711.00', 'currency': 'USD'}
+Money("4711 USD").asdict(keys=("value", "units", "nanos", "currency_code"))
+# {'value': '4711.00 USD', 'units': 4711, 'nanos': 0, 'currency_code': 'USD'}
 
-  Money(nanos=10).asdict(keys=("value", "currency", "units", "nanos"))
-  # {'value': '0.00000001', 'currency': None, 'units': 0, 'nanos': 10}
-  ```
+Money("4711 USD").asdict(keys=("amount", "currency"))
+# {'amount': '4711.00', 'currency': 'USD'}
+
+Money(nanos=10).asdict(keys=("value", "currency", "units", "nanos"))
+# {'value': '0.00000001', 'currency': None, 'units': 0, 'nanos': 10}
+```
 
 
 ## [0.5.3] - 2022-10-25

--- a/README.md
+++ b/README.md
@@ -27,38 +27,39 @@
 
 ![stockholm.Money](https://user-images.githubusercontent.com/89139/123852607-c9a0c380-d91c-11eb-9d47-cf7cd5751c01.png)
 
-### Brief description with basic examples
+### Basic examples
 
 Basically `stockholm` is a human friendly and modern `Money` class for Python 3. This is a library to be used by backend and frontend API coders of fintech companies, web merchants or subscription services. It's great for calculations of amounts while keeping a great level of precision.
 
 ```python
 from stockholm import Money, Rate
-from stockholm.currency import GBP
 
-loan_amount = Money("250380.00", GBP)
-# <stockholm.Money: "250380.00 GBP">
+loan_amount = Money("250380.00", currency="EUR")
+# <stockholm.Money: "250380.00 EUR">
 
 interest_rate = Rate(0.073)
 # <stockholm.Rate: "0.073">
 
 interest_per_day = loan_amount * (interest_rate / 365)
-# <stockholm.Money: "50.076 GBP">
+# <stockholm.Money: "50.076 EUR">
 ```
 
 Comes with functions to produce output for transport layers as well as having a robust and easy way to import/export values in *GraphQL*, *JSON*, *Protocol Buffers*, etc.
 
 ```python
 interest_per_day.asdict()
-# {'value': '50.076 GBP', 'units': 50, 'nanos': 76000000, 'currency_code': 'GBP'}
+# {'value': '50.076 EUR', 'units': 50, 'nanos': 76000000, 'currency_code': 'EUR'}
+```
 
+```
 interest_per_day.asdict(keys=("amount", "currency"))
-# {'amount': '50.076', 'currency': 'GBP'}
+# {'amount': '50.076', 'currency': 'EUR'}
 ```
 
 ```python
 interest_per_day.as_protobuf()
 # <class 'google.type.money_pb2.Money'>
-# · currency_code: "GBP"
+# · currency_code: "EUR"
 # · units: 50
 # · nanos: 76000000
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 *Library for formatting and performing arithmetic and comparison operations on monetary amounts. Also with support for currency handling, rates, exchange and serialization + deserialization for when transporting monetary amount data across network layers (built-in data generation and parsing).* 💰
 
-### Why a library for monetary amounts - why this library?
+### A library for monetary amounts
 
 * Combining an amount with a currency to create a monetary amount, as they usually should be read, written and transported together.
 * Able to work with a plethora of different source types. Human friendly approach with developer experience in mind.
@@ -18,14 +18,16 @@
 * Generate (and parse) structured data to be used in transport layers such as GraphQL or Protobuf.
 * Type hinted, battle tested and supporting several versions of Python.
 
-In its simplest form:
+#### Full feature set further down, but in its simplest form
 
 ```pycon
->>> Money("9001.42", currency=USD)
+>>> Money("9001.42", currency="USD")
 <stockholm.Money: "9001.42 USD">
 ```
 
 ![stockholm.Money](https://user-images.githubusercontent.com/89139/123852607-c9a0c380-d91c-11eb-9d47-cf7cd5751c01.png)
+
+### Brief description with basic examples
 
 Basically `stockholm` is a human friendly and modern `Money` class for Python 3. This is a library to be used by backend and frontend API coders of fintech companies, web merchants or subscription services. It's great for calculations of amounts while keeping a great level of precision.
 
@@ -87,7 +89,7 @@ total_sum / 4  # total split on four people
 
 Coding applications, libaries and microservices that consume and publish events that contain monetary amounts shouldn't be any harder than anything else. This package aims to ease that work. You can also use it for just numerical values of course.
 
-### When to use `stockholm`
+#### Real life use-cases
 
 There are times when you want to receive or publish events with monetary amounts or you need to expose an API endpoint and have a structured way to respond with balances, prices, vat, etc. without risking additional weirdness.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # `stockholm`
+
 **This brings a fully featured `Money` class for Python 3 – `stockholm.Money`.**
 
 ![Python package](https://github.com/kalaspuff/stockholm/workflows/Python%20package/badge.svg)
 [![pypi](https://badge.fury.io/py/stockholm.svg)](https://pypi.python.org/pypi/stockholm/)
 [![Made with Python](https://img.shields.io/pypi/pyversions/stockholm)](https://www.python.org/)
-[![Type hinted - mypy validated](https://img.shields.io/badge/typehinted-yes-teal)](https://github.com/kalaspuff/stockholm)
 [![MIT License](https://img.shields.io/github/license/kalaspuff/stockholm.svg)](https://github.com/kalaspuff/stockholm/blob/master/LICENSE)
 [![Code coverage](https://codecov.io/gh/kalaspuff/stockholm/branch/master/graph/badge.svg)](https://codecov.io/gh/kalaspuff/stockholm/tree/master/stockholm)
 
-*Library for formatting and performing arithmetic and comparison operations on monetary amounts. Also with support for currency handling, rates, exchange and serialization + deserialization for when transporting monetary amount data across network layers (built-in data generation and parsing).*
+*Library for formatting and performing arithmetic and comparison operations on monetary amounts. Also with support for currency handling, rates, exchange and serialization + deserialization for when transporting monetary amount data across network layers (built-in data generation and parsing).* 💰
 
 ### Why a library for monetary amounts - why this library?
 
-* Combine a value with a currency, as they usually should be read, written and transported together.
+* Combining an amount with a currency to create a monetary amount, as they usually should be read, written and transported together.
 * Able to work with a plethora of different source types. Human friendly approach with developer experience in mind.
 * Get rid of the gotchas if otherwise using `decimal.Decimal`. Sensible rounding by default. Never lose precision when making arithmetic operations. String output as you would expect.
 * Generate (and parse) structured data to be used in transport layers such as GraphQL or Protobuf.
@@ -29,67 +29,63 @@ In its simplest form:
 
 Basically `stockholm` is a human friendly and modern `Money` class for Python 3. This is a library to be used by backend and frontend API coders of fintech companies, web merchants or subscription services. It's great for calculations of amounts while keeping a great level of precision.
 
-```pycon
->>> from stockholm import Money, Rate
->>> from stockholm.currency import GBP
+```python
+from stockholm import Money, Rate
+from stockholm.currency import GBP
 
->>> loan_amount = Money("250380.00", GBP)
-<stockholm.Money: "250380.00 GBP">
+loan_amount = Money("250380.00", GBP)
+# <stockholm.Money: "250380.00 GBP">
 
->>> interest_rate = Rate(0.073)
-<stockholm.Rate: "0.073">
+interest_rate = Rate(0.073)
+# <stockholm.Rate: "0.073">
 
->>> # added interest per day - simple year calculation (365 days)
->>> interest_per_day = loan_amount * (interest_rate / 365)
-<stockholm.Money: "50.076 GBP">
+interest_per_day = loan_amount * (interest_rate / 365)
+# <stockholm.Money: "50.076 GBP">
 ```
 
 Comes with functions to produce output for transport layers as well as having a robust and easy way to import/export values in *GraphQL*, *JSON*, *Protocol Buffers*, etc.
 
-```pycon
->>> # by default asdict() uses "value", "units", "nanos", "currency_code"
->>> interest_per_day.asdict()
-{'value': '50.076 GBP', 'units': 50, 'nanos': 76000000, 'currency_code': 'GBP'}
+```python
+interest_per_day.asdict()
+# {'value': '50.076 GBP', 'units': 50, 'nanos': 76000000, 'currency_code': 'GBP'}
 
->>> # a set of alternative keys can be specified, for example to fit a graphql type
->>> interest_per_day.asdict(keys=("amount", "currency"))
-{'amount': '50.076', 'currency': 'GBP'}
+interest_per_day.asdict(keys=("amount", "currency"))
+# {'amount': '50.076', 'currency': 'GBP'}
 ```
 
-```pycon
->>> # transform monetary object to a protobuf message (default: google.type.Money)
->>> interest_per_day.as_protobuf()
-<class 'google.type.money_pb2.Money'>
-· currency_code: "GBP"
-· units: 50
-· nanos: 76000000
+```python
+interest_per_day.as_protobuf()
+# <class 'google.type.money_pb2.Money'>
+# · currency_code: "GBP"
+# · units: 50
+# · nanos: 76000000
 ```
 
 The goal is to provide a flexible and robust package for development with any kind of monetary amounts. No more working with floats or having to deal with having to think about values in subunits for data transport layers or losing hours of sleep because of the default way that `Decimal` does rounding.
 
 The monetary amounts can be transformed from (or into) dicts, strings, protobuf messages, json, floats, ints, Python Decimals, even other monetary amounts.
 
-Coding applications, libaries and microservices that consume and publish events that contain monetary amounts shouldn't be any harder than anything else. This package aims to ease that work. You can also use it for just numerical values of course.
+```python
+from stockholm import Money, Number
 
-```pycon
->>> from stockholm import Money, Number
+gross_price = Money("319.20 SEK")
+# <stockholm.Money: "319.20 SEK">
 
->>> gross_price = Money("319.20 SEK")
-<stockholm.Money: "319.20 SEK">
+vat_rate = Number(0.25)  # 25% vat
+vat_price = gross_price * vat_rate
+# <stockholm.Money: "79.80 SEK">
 
->>> vat_rate = Number(0.25)  # 25% vat
->>> vat_price = gross_price * vat_rate
-<stockholm.Money: "79.80 SEK">
+net_price = gross_price + vat_price
+# <stockholm.Money: "399.00 SEK">
 
->>> net_price = gross_price + vat_price
-<stockholm.Money: "399.00 SEK">
+total_sum = net_price * 5  # price of five items
+# <stockholm.Money: "1995.00 SEK">
 
->>> net_sum = net_price * 5  # price of five items
-<stockholm.Money: "1995.00 SEK">
-
->>> net_sum / 4  # split on four people
-<stockholm.Money: "498.75 SEK">
+total_sum / 4  # total split on four people
+# <stockholm.Money: "498.75 SEK">
 ```
+
+Coding applications, libaries and microservices that consume and publish events that contain monetary amounts shouldn't be any harder than anything else. This package aims to ease that work. You can also use it for just numerical values of course.
 
 ### When to use `stockholm`
 
@@ -97,7 +93,7 @@ There are times when you want to receive or publish events with monetary amounts
 
 If you're developing a merchant solution, a ticketing service or webshop it can be great to have easy and structured interfaces for calculating orders and building summaries or reports.
 
-#### We're no fan of `float`, but you can do more than just `int`
+#### We don't want to use `float`, but you can do more than just rely on `int` 🤔
 
 Some may be interfacing with banking infrastructure from the 70s or 80s 😓 and has to process data in insanly old string based formats like the example below and validate sums, currencies, etc.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * Generate (and parse) structured data to be used in transport layers such as GraphQL or Protobuf.
 * Type hinted, battle tested and supporting several versions of Python.
 
-#### Full feature set further down, but in its simplest form
+#### Full feature set further down, but in its simplest form 👇
 
 ```pycon
 >>> Money("9001.42", currency="USD")
@@ -107,7 +107,7 @@ If any of these sounds familiar, a library for handling monetary amounts could h
 
 ## The basic interfaces
 
-#### `from stockholm import Money`
+### `from stockholm import Money`
 
 The `stockholm.Money` object has full arithmetic support together with `int`, `float`, `Decimal`, other `Money` objects as well as `string`. The `stockholm.Money` object also supports complex string formatting functionality for easy debugging and a clean coding pattern.
 
@@ -118,7 +118,7 @@ Money("99.95 USD")
 # <stockholm.Money: "99.95 USD">
 ```
 
-#### `from stockholm import Currency`
+### `from stockholm import Currency`
 
 Currencies to monetary amounts can be specified using either currencies built with the `stockholm.Currency` metaclasses or simply by specifying the currency ticker as a string (for example `"SEK"` or `"EUR"`) when creating a new `Money` object.
 
@@ -139,7 +139,7 @@ Money(1000, Currency.JPY)
 
 Currencies using the `stockholm.Currency` metaclasses can hold additional options, such as default number of decimals in string output. Note that the amounts behind the scenes actually uses the same precision and backend as `Decimal` values and can as well be interchangable with such values, as such they are way more exact to do calculations with than floating point values.
 
-#### `from stockholm import Number, Rate`
+### `from stockholm import Number, Rate`
 
 The `Number` and `Rate` classes works in the same way and is similar to the `Money` class, with the exception that they cannot hold a currency type and cannot operate with sub units. Examples of when to use them could be to differentiate some values from monetary values, while still getting the benefits from the `Money` class.
 
@@ -181,10 +181,7 @@ $ pip install stockholm[protobuf]
   - [**Parsing and loading JSON data.**](#reading-or-outputting-monetary-amounts-as-json)
 * [**Parameters and functions of the `stockholm.Money` object.**](#parameters-of-the-money-object)
 
-
-## Usage and examples
-
-#### Arithmetics - fully supported
+### Arithmetics - fully supported
 
 *Full arithmetic support with different types, backed by `Decimal` for dealing with rounding errors, while also keeping the monetary amount fully currency aware.*
 
@@ -249,7 +246,7 @@ Money("5 EUR") * Money("5 EUR")
 
 ```
 
-#### Formatting / Advanced string formatting
+### Formatting and advanced string formatting
 
 *Advanced string formatting functionality.*
 
@@ -286,6 +283,8 @@ print(f"{sek_money:.4M}")  # SEK 119889.5760
 print(f"{sek_money:c}")  # SEK
 ```
 
+### Currency class
+
 ##### *Use `stockholm.Currency` types for proper defaults of minimum number of decimal digits to output in strings, etc. All ISO 4217 currency codes implemented, see https://github.com/kalaspuff/stockholm/blob/master/stockholm/currency.py for the full list.*
 
 ```python
@@ -315,6 +314,8 @@ print(Money(1338, Currency.JPY))  # 1338 JPY
 print(Money(1338, get_currency("JPY")))  # 1338 JPY
 
 ```
+
+### Parsing input
 
 #### Input data types in flexible variants
 
@@ -351,7 +352,7 @@ money.sub_units
 # Decimal('471100')
 ```
 
-#### List arithmetics - summary of monetary amounts in list
+### List arithmetics - summary of monetary amounts in list
 
 *Adding several monetary amounts from a list.*
 
@@ -373,7 +374,7 @@ sum(amounts)
 # <stockholm.Money: "1002.50">
 ```
 
-#### Conversion for other transport medium (for example Protocol Buffers or JSON)
+### Conversion for other transport medium (for example Protocol Buffers or JSON)
 
 ##### *Easily splittable into `units` and `nanos` for transport in network medium, for example using the [`google.type.Money` protobuf definition](https://github.com/googleapis/googleapis/blob/master/google/type/money.proto) when using Protocol Buffers.*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stockholm"
-version = "0.5.3"
+version = "0.5.4"
 description = "Human friendly and flexible package for working with monetary amounts"
 authors = ["Carl Oscar Aaro <hello@carloscar.com>"]
 homepage = "https://github.com/kalaspuff/stockholm"

--- a/stockholm/__init__.py
+++ b/stockholm/__init__.py
@@ -4,7 +4,7 @@ from .currency import BaseCurrency, Currency, DefaultCurrency, DefaultCurrencyVa
 from .exceptions import ConversionError, CurrencyMismatchError, InvalidOperandError, MoneyException  # noqa
 from .money import Money, MoneyType  # noqa
 from .protobuf import MoneyProtobufMessage
-from .rate import ExchangeRate, Rate  # noqa
+from .rate import ExchangeRate, Number, Rate  # noqa
 
 __author__ = "Carl Oscar Aaro"
 __email__ = "hello@carloscar.com"
@@ -27,6 +27,7 @@ __all__ = [
     "Money",
     "MoneyProtobufMessage",
     "MoneyType",
+    "Number",
     "ExchangeRate",
     "Rate",
 ]

--- a/stockholm/rate.py
+++ b/stockholm/rate.py
@@ -101,7 +101,7 @@ class Rate(Money):
             max_decimals = DEFAULT_MAX_DECIMALS
         return super().amount_as_string(min_decimals=min_decimals, max_decimals=max_decimals)
 
-    def to_currency(self, currency: Optional[Union[CurrencyValue, str]]) -> MoneyType:  # type: ignore
+    def to_currency(self, currency: Optional[Union[CurrencyValue, str]]) -> Money:
         return Money(self, currency=currency)
 
     def to_sub_units(self) -> MoneyType:  # type: ignore

--- a/stockholm/rate.py
+++ b/stockholm/rate.py
@@ -102,7 +102,7 @@ class Rate(Money):
         return super().amount_as_string(min_decimals=min_decimals, max_decimals=max_decimals)
 
     def to_currency(self, currency: Optional[Union[CurrencyValue, str]]) -> MoneyType:  # type: ignore
-        raise ConversionError("Rates and numbers does not have a currency")
+        return Money(self, currency=currency)
 
     def to_sub_units(self) -> MoneyType:  # type: ignore
         raise ConversionError("Rates and numbers cannot be measured in sub units")
@@ -115,3 +115,11 @@ class Rate(Money):
 
 
 ExchangeRate = Rate
+
+
+class Number(Rate):
+    def __repr__(self) -> str:
+        return f'<stockholm.Number: "{self}">'
+
+    def __hash__(self) -> int:
+        return hash(("stockholm.Number", self._amount))

--- a/stockholm/rate.py
+++ b/stockholm/rate.py
@@ -1,11 +1,15 @@
 import decimal
+import json
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from .compat import CurrencyValue
 from .currency import DefaultCurrency, DefaultCurrencyValue
 from .exceptions import ConversionError
 from .money import Money, MoneyType
+
+DEFAULT_MIN_DECIMALS = 0
+DEFAULT_MAX_DECIMALS = 9
 
 RoundingContext = decimal.Context(rounding=ROUND_HALF_UP)
 
@@ -22,7 +26,7 @@ class Rate(Money):
         currency_code: Optional[str] = None,
         **kwargs: Any,
     ) -> "Rate":
-        raise ConversionError("Rates cannot be created from sub units")
+        raise ConversionError("Rates and numbers cannot be created from sub units")
 
     @classmethod
     def from_dict(cls, input_dict: Dict) -> "Rate":
@@ -31,24 +35,24 @@ class Rate(Money):
     def __init__(
         self,
         amount: Optional[Union[MoneyType, Decimal, Dict, int, float, str, object]] = None,
-        currency: Optional[Union[DefaultCurrencyValue, CurrencyValue, str]] = DefaultCurrency,
-        from_sub_units: Optional[bool] = None,
         units: Optional[int] = None,
         nanos: Optional[int] = None,
         value: Optional[Union[MoneyType, Decimal, int, float, str]] = None,
-        currency_code: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        currency = kwargs.get("currency", DefaultCurrency)
+        currency_code = kwargs.get("currency_code")
+        from_sub_units = kwargs.get("from_sub_units")
         if (currency is not DefaultCurrency and currency is not None) or currency_code is not None:
-            raise ConversionError("Rates does not have a currency")
+            raise ConversionError("Rates and numbers does not have a currency")
         if from_sub_units is not None:
-            raise ConversionError("Rates cannot be created from sub units")
+            raise ConversionError("Rates and numbers cannot be created from sub units")
 
         cls = self.__class__.__bases__[0]
         money = cast(MoneyType, cls(amount=amount, units=units, nanos=nanos, value=value, **kwargs))
 
         if money._currency:
-            raise ConversionError("Rates does not have a currency")
+            raise ConversionError("Rates and numbers does not have a currency")
 
         object.__setattr__(self, "_amount", money._amount)
         object.__setattr__(self, "_currency", None)
@@ -63,16 +67,45 @@ class Rate(Money):
 
     @property
     def sub_units(self) -> Decimal:
-        raise ConversionError("Rates cannot be measured in sub units")
+        raise ConversionError("Rates and numbers cannot be measured in sub units")
 
-    def asdict(self) -> Dict:
-        return {"value": self.value, "units": self.units, "nanos": self.nanos}
+    def asdict(
+        self, keys: Union[List[str], Tuple[str, ...]] = ("value", "units", "nanos")
+    ) -> Dict[str, Optional[Union[str, int]]]:
+        output: Dict[str, Optional[Union[str, int]]] = {}
+        for key in keys:
+            if key in ("value", "amount"):
+                output[key] = self.value
+            elif key == "units":
+                output[key] = self.units
+            elif key == "nanos":
+                output[key] = self.nanos
+
+        return output
+
+    def as_dict(
+        self, keys: Union[List[str], Tuple[str, ...]] = ("value", "units", "nanos")
+    ) -> Dict[str, Optional[Union[str, int]]]:
+        return self.asdict(keys=keys)
+
+    def as_json(self, keys: Union[List[str], Tuple[str, ...]] = ("value", "units", "nanos")) -> str:
+        return json.dumps(self.asdict(keys=keys))
+
+    def json(self, keys: Union[List[str], Tuple[str, ...]] = ("value", "units", "nanos")) -> str:
+        return self.as_json(keys=keys)
+
+    def amount_as_string(self, min_decimals: Optional[int] = None, max_decimals: Optional[int] = None) -> str:
+        if min_decimals is None:
+            min_decimals = DEFAULT_MIN_DECIMALS
+        if max_decimals is None:
+            max_decimals = DEFAULT_MAX_DECIMALS
+        return super().amount_as_string(min_decimals=min_decimals, max_decimals=max_decimals)
 
     def to_currency(self, currency: Optional[Union[CurrencyValue, str]]) -> MoneyType:  # type: ignore
-        raise ConversionError("Rates does not have a currency")
+        raise ConversionError("Rates and numbers does not have a currency")
 
     def to_sub_units(self) -> MoneyType:  # type: ignore
-        raise ConversionError("Rates cannot be measured in sub units")
+        raise ConversionError("Rates and numbers cannot be measured in sub units")
 
     def __repr__(self) -> str:
         return f'<stockholm.Rate: "{self}">'

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -40,6 +40,37 @@ def test_asdict():
         Money(1338, currency=Currency.SEK)["does_not_exist"]
 
 
+def test_asdict_with_keys():
+    assert Money("4711.25", currency=Currency.SEK).asdict(keys=("amount", "currency", "units", "nanos")) == {
+        "amount": "4711.25",
+        "currency": "SEK",
+        "units": 4711,
+        "nanos": 250000000,
+    }
+    assert Money("1337 USD").asdict(keys=("amount", "currency", "sub_units")) == {
+        "amount": "1337.00",
+        "currency": "USD",
+        "sub_units": "133700",
+    }
+    assert Money("1337", currency=Currency.JPY).asdict(keys=("amount", "currency", "sub_units")) == {
+        "amount": "1337",
+        "currency": "JPY",
+        "sub_units": "1337",
+    }
+    assert Money("0.00000001", currency=Currency("EUR")).asdict(
+        keys=("value", "units", "nanos", "amount", "currency", "currency_code", "from_sub_units", "sub_units")
+    ) == {
+        "value": "0.00000001 EUR",
+        "units": 0,
+        "nanos": 10,
+        "amount": "0.00000001",
+        "currency": "EUR",
+        "currency_code": "EUR",
+        "from_sub_units": False,
+        "sub_units": "0.000001",
+    }
+
+
 def test_from_dict():
     input_dict = {"value": "13384711 JPY", "units": 13384711, "nanos": 0, "currency_code": "JPY"}
     assert str(Money.from_dict(input_dict)) == "13384711.00 JPY"

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -14,7 +14,12 @@ def test_rate():
     assert Rate(100).currency is None
     assert Rate(100).currency_code is None
     assert Rate(100).amount == 100
-    assert Rate(100).value == "100.00"
+    assert Rate(100).value == "100"
+
+    assert Rate(100.5).amount == 100.5
+    assert Rate(100.5).value == "100.5"
+    assert Rate(100.50).value == "100.5"
+    assert Rate(100.42).value == "100.42"
 
     assert Rate(50) < 51
     assert Rate(50) > 49
@@ -22,8 +27,8 @@ def test_rate():
 
     assert Rate(50) + Rate(50) == 100
     assert (Rate(50) + Rate(50)).__class__ is Rate
-    assert str(Rate(50) + Rate(50)) == "100.00"
-    assert repr(Rate(50) + Rate(50)) == '<stockholm.Rate: "100.00">'
+    assert str(Rate(50) + Rate(50)) == "100"
+    assert repr(Rate(50) + Rate(50)) == '<stockholm.Rate: "100">'
 
     assert (Rate(50) + Rate(50) + Money(50)).__class__ is Money
     assert str(Rate(50) + Rate(50) + Money(50)) == "150.00"
@@ -63,7 +68,7 @@ def test_rate_hashable() -> None:
 
 def test_rate_asdict():
     assert Rate(1338).asdict() == {
-        "value": "1338.00",
+        "value": "1338",
         "units": 1338,
         "nanos": 0,
     }
@@ -78,7 +83,7 @@ def test_rate_asdict():
         "nanos": 123456000,
     }
     assert dict(Rate("0.1")) == {
-        "value": "0.10",
+        "value": "0.1",
         "units": 0,
         "nanos": 100000000,
     }
@@ -86,20 +91,44 @@ def test_rate_asdict():
     assert Rate(1338).keys() == ["value", "units", "nanos"]
 
     assert Rate(1338)["units"] == 1338
-    assert Rate(1338)["value"] == "1338.00"
+    assert Rate(1338)["value"] == "1338"
 
     with pytest.raises(KeyError):
         Rate(1338)["does_not_exist"]
 
 
+def test_asdict_with_keys():
+    assert Rate(1338).asdict(keys=("value", "amount")) == {
+        "value": "1338",
+        "amount": "1338",
+    }
+    assert Rate("1338.4711").as_dict(keys=("value", "amount")) == {
+        "value": "1338.4711",
+        "amount": "1338.4711",
+    }
+
+
 def test_rate_from_dict():
     d = {"value": "13384711", "units": 13384711, "nanos": 0}
-    assert str(Rate.from_dict(d)) == "13384711.00"
-    assert str(Rate(d)) == "13384711.00"
+    assert str(Rate.from_dict(d)) == "13384711"
+    assert str(Rate(d)) == "13384711"
+
+    d = {"units": 5, "nanos": 100000}
+    assert str(Rate.from_dict(d)) == "5.0001"
+    assert str(Rate(d)) == "5.0001"
 
 
 def test_rate_json():
     rate = Rate("-999999999999999999.999999999")
     json_string = json.dumps({"rate": rate.asdict()})
+    assert str(Rate(json.loads(json_string).get("rate"))) == "-999999999999999999.999999999"
 
-    str(Rate(json.loads(json_string).get("rate"))) == "-999999999999999999.999999999"
+    assert (
+        Rate({"units": 5, "nanos": 100000}).as_json()
+        == Rate({"units": 5, "nanos": 100000}).json()
+        == '{"value": "5.0001", "units": 5, "nanos": 100000}'
+    )
+
+    assert str(Rate(Rate({"amount": "13.095"}).as_json())) == "13.095"
+    assert str(Rate(Rate({"units": 13, "nanos": 95000000}).as_json())) == "13.095"
+    assert str(Rate(Rate({"nanos": 10}).as_json())) == "0.00000001"

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 import stockholm
-from stockholm import ConversionError, ExchangeRate, Money, Rate
+from stockholm import ConversionError, ExchangeRate, Money, Number, Rate
 
 
 def test_rate():
@@ -38,6 +38,23 @@ def test_rate():
     assert Rate(Money(100)).__class__ is Rate
 
 
+def test_number():
+    assert Number(100) == 100
+    assert Number("100.50551") == 100.50551
+    assert str(Number("4711.1338")) == "4711.1338"
+
+    assert Number(100.50).value == "100.5"
+    assert Number(100.42).value == "100.42"
+    assert Number(nanos=10).value == "0.00000001"
+
+    assert repr(Number(0.00001) + Number(53.5)) == '<stockholm.Number: "53.50001">'
+    assert (Number(0.00001) + Number(53.5)).asdict() == {"nanos": 500010000, "units": 53, "value": "53.50001"}
+
+    assert str(Number(1.5).to_currency("USD")) == "1.50 USD"
+
+    assert Number(Money(100)).__class__ is Number
+
+
 def test_bad_rates():
     with pytest.raises(ConversionError):
         Rate(1, currency="EUR")
@@ -52,9 +69,6 @@ def test_bad_rates():
         Rate.from_sub_units(100)
 
     with pytest.raises(ConversionError):
-        Rate(1).to_currency("SEK")
-
-    with pytest.raises(ConversionError):
         Rate(1).to_sub_units()
 
     with pytest.raises(ConversionError):
@@ -62,8 +76,15 @@ def test_bad_rates():
 
 
 def test_rate_hashable() -> None:
-    m = stockholm.Rate(0)
-    assert hash(m)
+    r1 = stockholm.Rate(0)
+    r2 = stockholm.Rate(0)
+    r3 = stockholm.Rate(1)
+    n = stockholm.Number(0)
+
+    assert hash(r1)
+    assert hash(r1) == hash(r2)
+    assert hash(r1) != hash(r3)
+    assert hash(r1) != hash(n)
 
 
 def test_rate_asdict():


### PR DESCRIPTION
The `money.asdict()` function can now be called with an optional `keys` argument, which can be used to specify a tuple of keys which shuld be used in the returned dict.

The default behaviour has not changed. `money.asdict()` is equivalent to `money.asdict(keys=("value", "units", "nanos", "currency_code"))`.

Values to use in the `keys` tuple for `stockholm.Money` objects are any combination of the following:

| key | description | return type | example |
| :-- | :---------- | :---------- | -------: |
| `value` | amount + currency code | `str` | `"9001.50 USD"`
| `units` | units of the amount | `int` | `9001` |
| `nanos` | number of nano units of the amount | `int` | `500000000` |
| `currency_code` | currency code if available | `str \| None` | `"USD"` |
| `currency` | currency code if available | `str \| None` | `"USD"` |
| `amount` | the monetary amount (excl. currency code) | `str` | `"9001.50"` |

Code example:

```python
from stockholm import Money

Money("4711 USD").asdict(keys=("value", "units", "nanos", "currency_code"))
# {'value': '4711.00 USD', 'units': 4711, 'nanos': 0, 'currency_code': 'USD'}

Money("4711 USD").asdict(keys=("amount", "currency"))
# {'amount': '4711.00', 'currency': 'USD'}

Money(nanos=10).asdict(keys=("value", "currency", "units", "nanos"))
# {'value': '0.00000001', 'currency': None, 'units': 0, 'nanos': 10}
```