### PR TITLE
Support for Python 3.12

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,9 +9,9 @@ jobs:
     env:
       POETRY_VIRTUALENVS_CREATE: false
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.1']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.5.6] - 2023-08-15
 
 * Added so that `Money`, `Number` and `Rate` objects can now be copied using the `copy.copy()` and `copy.deepcopy()` functions.
+* Python 3.12 added to test matrix and trove classifiers.
 
 ## [0.5.5] - 2022-12-07
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -757,4 +757,4 @@ protobuf = ["protobuf"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "75e865f87bec6e3b54fc41e31c4c7b7a44a34875be7f39cc194c78cefd399a59"
+content-hash = "1581a268a1db0fc1576399c2e0d2da4aaad0f264521ff7a3e4b9207f0c639fa2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ protobuf = { version = ">=3.20.0,<5.0.0", optional = true }
 [tool.poetry.dev-dependencies]
 flake8 = { version = ">=3.8.4", markers = "sys_platform != \"win32\"" }
 flake8-black = { version = ">=0.2.0", markers = "sys_platform != \"win32\"" }
-flake8-isort = { version = ">=4.0.0", markers = "sys_platform != \"win32\"" }
+flake8-isort = { version = ">=4.0.0", markers = "python_version < \"3.12\" and sys_platform != \"win32\"" }
 flake8-pyproject = { version = ">=1.1.0", markers = "sys_platform != \"win32\"" }
 isort = { version = ">=5.6.0", markers = "sys_platform != \"win32\"" }
 pytest = { version = ">=6.1.0", markers = "sys_platform != \"win32\"" }
@@ -42,7 +42,7 @@ mypy = { version = ">=0.800", markers = "sys_platform != \"win32\"" }
 codecov = { version = ">=2.1.10", markers = "sys_platform != \"win32\"" }
 protobuf = { version = ">=3.20.0,<5.0.0", markers = "sys_platform != \"win32\"" }
 types-protobuf = { version = ">=0.1.13", markers = "sys_platform != \"win32\"" }
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\" and sys_platform != \"win32\""}
+typing-extensions = { version = ">=3.7.4", markers = "python_version < \"3.8\" and sys_platform != \"win32\"" }
 
 [tool.poetry.extras]
 protobuf = ["protobuf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Intended Audience :: Financial and Insurance Industry",
     "Typing :: Typed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.flake8]
-ignore = ["E203", "E501", "W503", "E231]
+ignore = ["E203", "E501", "W503", "E231"]
 exclude = ["stockholm.egg-info", ".git", ".mypy_cache", ".pytest_cache", ".venv", ".vscode", "__pycache__", "build", "dist", "tmp"]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.flake8]
-ignore = ["E203", "E501", "W503"]
+ignore = ["E203", "E501", "W503", "E231]
 exclude = ["stockholm.egg-info", ".git", ".mypy_cache", ".pytest_cache", ".venv", ".vscode", "__pycache__", "build", "dist", "tmp"]
 
 [tool.coverage.run]


### PR DESCRIPTION
* Currently `flake8-isort` is disabled linting on Python 3.12 as it fails with an `ModuleNotFoundError: No module named 'pkg_resources'` error.